### PR TITLE
Adding Sort by Mesh Sorting Order

### DIFF
--- a/Editor/MeshCombinerWindow.CombineMeshes.cs
+++ b/Editor/MeshCombinerWindow.CombineMeshes.cs
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * The MIT License (MIT)
  *
  * Copyright (c) 2023 Jeremy Lam aka. Vistanz
@@ -27,25 +27,29 @@ using UnityEditor;
 using UnityEditorInternal;
 using JLChnToZ.CommonUtils;
 
-namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner {
+namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner
+{
     using static Utils;
-    public partial class MeshCombinerWindow : EditorWindow {
+    public partial class MeshCombinerWindow : EditorWindow
+    {
         const string COMBINE_MESH_INFO = "Select (skinned) mesh renderer(s) and/or its parent, and click \"+\" button to add to the combine list.\n" +
             "Even it is not necessary in many cases, you may drag to change the processing order.\n" +
             "You can expand the options such as baking blendshapes by clicking on the arrow on the left.\n" +
             "You can use the checkbox on the right to toggle all options within the renderer while expanded the view.\n" +
             "It is recommend to bake the blendshapes that unlikely to be changed after build for better performance and smaller file size.\n" +
             "If the blendshape is a \"anti-penetration\" key for hiding skins under clothes, you can use the dropdown to select remove blendshape vertex to reduce triangles and vertices.";
-            
+
 
         [Serializable]
-        struct BakeBlendShapeToggles {
+        struct BakeBlendShapeToggles
+        {
             public CombineBlendshapeFlags[] blendShapeFlags;
             public CombineMeshFlags combineMeshFlags;
             public bool toggleState;
             public string[] blendShapeNames;
 
-            public BakeBlendShapeToggles(CombineBlendshapeFlags[] blendShapeFlags, CombineMeshFlags combineMeshFlags, bool toggleState, string[] blendShapeNames) {
+            public BakeBlendShapeToggles(CombineBlendshapeFlags[] blendShapeFlags, CombineMeshFlags combineMeshFlags, bool toggleState, string[] blendShapeNames)
+            {
                 this.blendShapeFlags = blendShapeFlags;
                 this.combineMeshFlags = combineMeshFlags;
                 this.toggleState = toggleState;
@@ -53,7 +57,7 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner {
             }
         }
 
-        [Serializable] class BakeBlendShapeMap : SerializableDictionary<Renderer, BakeBlendShapeToggles> {}
+        [Serializable] class BakeBlendShapeMap : SerializableDictionary<Renderer, BakeBlendShapeToggles> { }
 
         Vector2 sourceListScrollPos;
         List<Renderer> sources = new List<Renderer>();
@@ -62,28 +66,34 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner {
         BlendShapeCopyMode blendShapeCopyMode = BlendShapeCopyMode.Vertices;
         ReorderableList sourceList;
 
-        static CombineMeshFlags DrawFlag(CombineMeshFlags mergeFlags, string label, CombineMeshFlags flag) {
+        static CombineMeshFlags DrawFlag(CombineMeshFlags mergeFlags, string label, CombineMeshFlags flag)
+        {
             EditorGUI.BeginChangeCheck();
             var state = EditorGUILayout.ToggleLeft(label, mergeFlags.HasFlag(flag));
-            if (EditorGUI.EndChangeCheck()) {
+            if (EditorGUI.EndChangeCheck())
+            {
                 if (state) mergeFlags |= flag;
                 else mergeFlags &= ~flag;
             }
             return mergeFlags;
         }
 
-        static CombineMeshFlags DrawFlag(CombineMeshFlags mergeFlags, Rect position, string label, CombineMeshFlags flag) {
+        static CombineMeshFlags DrawFlag(CombineMeshFlags mergeFlags, Rect position, string label, CombineMeshFlags flag)
+        {
             EditorGUI.BeginChangeCheck();
             var state = EditorGUI.ToggleLeft(position, label, mergeFlags.HasFlag(flag));
-            if (EditorGUI.EndChangeCheck()) {
+            if (EditorGUI.EndChangeCheck())
+            {
                 if (state) mergeFlags |= flag;
                 else mergeFlags &= ~flag;
             }
             return mergeFlags;
         }
 
-        void InitCombineMeshTab() {
-            sourceList = new ReorderableList(sources, typeof(Renderer), true, false, true, true) {
+        void InitCombineMeshTab()
+        {
+            sourceList = new ReorderableList(sources, typeof(Renderer), true, false, true, true)
+            {
                 drawElementCallback = OnListDrawElement,
                 elementHeightCallback = OnListGetElementHeight,
                 onAddCallback = OnListAdd,
@@ -93,12 +103,22 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner {
             };
         }
 
-        void DrawCombineMeshTab() {
+        void DrawCombineMeshTab()
+        {
             EditorGUILayout.HelpBox(COMBINE_MESH_INFO, MessageType.Info);
             sourceListScrollPos = EditorGUILayout.BeginScrollView(sourceListScrollPos);
             sourceList.DoLayoutList();
             EditorGUILayout.EndScrollView();
+
+            #region Add Sorting Button
             EditorGUILayout.BeginHorizontal();
+            if (GUILayout.Button("Sort by Mesh Sorting Order Ascending ↑", EditorStyles.miniButton, GUILayout.ExpandWidth(false))) AutoOrderRenderer(false);
+            if (GUILayout.Button("Sort by Mesh Sorting Order Descending ↓", EditorStyles.miniButton, GUILayout.ExpandWidth(false))) AutoOrderRenderer();
+            EditorGUILayout.EndHorizontal();
+            #endregion
+
+            EditorGUILayout.BeginHorizontal();
+
             EditorGUI.BeginChangeCheck();
             var newDestination = EditorGUILayout.ObjectField("Destination", destination, typeof(Renderer), true) as Renderer;
             if (EditorGUI.EndChangeCheck() && (
@@ -106,21 +126,26 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner {
                 newDestination is SkinnedMeshRenderer ||
                 (newDestination is MeshRenderer && newDestination.TryGetComponent(out MeshFilter _))))
                 destination = newDestination;
-            if (destination == null) {
-                if (GUILayout.Button("Auto Create", EditorStyles.miniButtonLeft, GUILayout.ExpandWidth(false))) {
+            if (destination == null)
+            {
+                if (GUILayout.Button("Auto Create", EditorStyles.miniButtonLeft, GUILayout.ExpandWidth(false)))
+                {
                     destination = AutoCreateRenderer<SkinnedMeshRenderer>();
                     EditorGUIUtility.PingObject(destination);
                 }
                 if (dropdownIcon == null) dropdownIcon = EditorGUIUtility.IconContent("d_icon dropdown");
                 var dropdownButtonSize = EditorStyles.miniButtonRight.CalcSize(dropdownIcon);
                 var dropdownButtonRect = GUILayoutUtility.GetRect(dropdownButtonSize.x, dropdownButtonSize.y, EditorStyles.miniButtonRight, GUILayout.ExpandWidth(false));
-                if (GUI.Button(dropdownButtonRect, dropdownIcon, EditorStyles.miniButtonRight)) {
+                if (GUI.Button(dropdownButtonRect, dropdownIcon, EditorStyles.miniButtonRight))
+                {
                     var menu = new GenericMenu();
-                    menu.AddItem(new GUIContent("Skinned Mesh Renderer"), false, () => {
+                    menu.AddItem(new GUIContent("Skinned Mesh Renderer"), false, () =>
+                    {
                         destination = AutoCreateRenderer<SkinnedMeshRenderer>();
                         EditorGUIUtility.PingObject(destination);
                     });
-                    menu.AddItem(new GUIContent("Mesh Renderer"), false, () => {
+                    menu.AddItem(new GUIContent("Mesh Renderer"), false, () =>
+                    {
                         destination = AutoCreateRenderer<MeshRenderer>();
                         EditorGUIUtility.PingObject(destination);
                     });
@@ -138,15 +163,17 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner {
             EditorGUILayout.EndHorizontal();
         }
 
-        
-        void OnListDrawElement(Rect rect, int index, bool isActive, bool isFocused) {
+
+        void OnListDrawElement(Rect rect, int index, bool isActive, bool isFocused)
+        {
             bool isMeshRenderer = destination is MeshRenderer;
             var renderer = sources[index];
             rect.height = EditorGUIUtility.singleLineHeight;
             var rect2 = rect;
             rect2.xMin += 12;
             rect2.xMax -= 150;
-            if (GUI.Button(rect2, renderer == null ? new GUIContent("(Missing)") : EditorGUIUtility.ObjectContent(renderer, renderer.GetType()), EditorStyles.label)) {
+            if (GUI.Button(rect2, renderer == null ? new GUIContent("(Missing)") : EditorGUIUtility.ObjectContent(renderer, renderer.GetType()), EditorStyles.label))
+            {
                 EditorGUIUtility.PingObject(renderer);
                 if (!isFocused) sourceList.index = index;
             }
@@ -160,7 +187,8 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner {
             if (!bakeBlendShapeToggles.toggleState) return;
             rect2.width = rect.width;
             rect2.y += EditorGUIUtility.singleLineHeight;
-            if (renderer is SkinnedMeshRenderer) {
+            if (renderer is SkinnedMeshRenderer)
+            {
                 var newFlags = bakeBlendShapeToggles.combineMeshFlags;
                 newFlags = DrawFlag(newFlags, rect2, "Remove sub meshes without materials", CombineMeshFlags.RemoveSubMeshWithoutMaterials);
                 rect2.y += EditorGUIUtility.singleLineHeight;
@@ -168,14 +196,16 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner {
                 rect2.y += EditorGUIUtility.singleLineHeight;
                 newFlags = DrawFlag(newFlags, rect2, "Remove mesh portions with 0-scale bones", CombineMeshFlags.RemoveMeshPortionsWithZeroScaleBones);
                 rect2.y += EditorGUIUtility.singleLineHeight;
-                if (newFlags != bakeBlendShapeToggles.combineMeshFlags) {
+                if (newFlags != bakeBlendShapeToggles.combineMeshFlags)
+                {
                     bakeBlendShapeToggles.combineMeshFlags = newFlags;
                     bakeBlendShapeMap[renderer] = bakeBlendShapeToggles;
                 }
                 if (bakeBlendShapeToggles.blendShapeFlags.Length <= 0) return;
                 bool state = false, isMixed = false, isMixed2 = false;
                 var states2 = CombineBlendshapeFlags.None;
-                for (var i = 0; i < bakeBlendShapeToggles.blendShapeFlags.Length; i++) {
+                for (var i = 0; i < bakeBlendShapeToggles.blendShapeFlags.Length; i++)
+                {
                     bool currentState = isMeshRenderer || bakeBlendShapeToggles.blendShapeFlags[i] != CombineBlendshapeFlags.None;
                     rect2.width = rect.width - 128 - rect2.x;
                     EditorGUI.BeginChangeCheck();
@@ -194,10 +224,13 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner {
                     if (EditorGUI.EndChangeCheck()) bakeBlendShapeToggles.blendShapeFlags[i] = flag;
                     rect2.y += EditorGUIUtility.singleLineHeight;
                     rect2.x = rect.x;
-                    if (i == 0) {
+                    if (i == 0)
+                    {
                         state = currentState;
                         states2 = flag;
-                    } else {
+                    }
+                    else
+                    {
                         if (currentState != state)
                             isMixed = true;
                         if (flag != states2)
@@ -225,23 +258,28 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner {
                 if (EditorGUI.EndChangeCheck())
                     for (var i = 0; i < bakeBlendShapeToggles.blendShapeFlags.Length; i++)
                         bakeBlendShapeToggles.blendShapeFlags[i] = state ? CombineBlendshapeFlags.CombineBlendShape : CombineBlendshapeFlags.None;
-            } else if (renderer is MeshRenderer) {
+            }
+            else if (renderer is MeshRenderer)
+            {
                 var newFlags = bakeBlendShapeToggles.combineMeshFlags;
                 EditorGUI.BeginChangeCheck();
                 EditorGUI.BeginDisabledGroup(isMeshRenderer);
                 if (isMeshRenderer) newFlags &= ~CombineMeshFlags.CreateBoneForNonSkinnedMesh;
                 newFlags = DrawFlag(newFlags, rect2, "Create bone for this mesh renderer", CombineMeshFlags.CreateBoneForNonSkinnedMesh);
                 EditorGUI.EndDisabledGroup();
-                if (EditorGUI.EndChangeCheck()) {
+                if (EditorGUI.EndChangeCheck())
+                {
                     bakeBlendShapeToggles.combineMeshFlags = newFlags;
                     bakeBlendShapeMap[renderer] = bakeBlendShapeToggles;
                 }
             }
         }
 
-        float OnListGetElementHeight(int index) {
+        float OnListGetElementHeight(int index)
+        {
             var source = sources[index];
-            if (bakeBlendShapeMap.TryGetValue(source, out var bakeBlendShapeToggles)) {
+            if (bakeBlendShapeMap.TryGetValue(source, out var bakeBlendShapeToggles))
+            {
                 if (bakeBlendShapeToggles.toggleState)
                     return EditorGUIUtility.singleLineHeight * (
                         source is SkinnedMeshRenderer ?
@@ -251,7 +289,8 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner {
             return EditorGUIUtility.singleLineHeight;
         }
 
-        void OnListAdd(ReorderableList list) {
+        void OnListAdd(ReorderableList list)
+        {
             var count = sources.Count;
             sources.AddRange(Selection.GetFiltered<Renderer>(SelectionMode.Deep).Where(IsAcceptableObject));
             if (count == sources.Count) return;
@@ -259,7 +298,8 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner {
             RefreshCombineMeshOptions();
         }
 
-        void OnListRemove(ReorderableList list) {
+        void OnListRemove(ReorderableList list)
+        {
             sources.RemoveAt(list.index);
             RefreshCombineMeshOptions();
         }
@@ -267,25 +307,31 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner {
         private void OnListDrawNoneElement(Rect rect) =>
             EditorGUI.LabelField(rect, "Click \"+\" button to add selected (skinned) mesh renderer to combine.");
 
-        void RefreshCombineMeshOptions() {
+        void RefreshCombineMeshOptions()
+        {
             var oldSources = new HashSet<Renderer>(bakeBlendShapeMap.Keys);
-            foreach (var source in sources) {
+            foreach (var source in sources)
+            {
                 Mesh mesh = null;
                 var skinnedMeshRenderer = source as SkinnedMeshRenderer;
                 if (skinnedMeshRenderer != null)
                     mesh = skinnedMeshRenderer.sharedMesh;
-                else {
+                else
+                {
                     var meshRenderer = source as MeshRenderer;
                     if (meshRenderer != null && source.TryGetComponent(out MeshFilter meshFilter))
                         mesh = meshFilter.sharedMesh;
                 }
                 if (mesh == null) continue;
                 int length = skinnedMeshRenderer != null ? mesh.blendShapeCount : 0;
-                if (bakeBlendShapeMap.TryGetValue(source, out var bakeBlendShapeToggles)) {
+                if (bakeBlendShapeMap.TryGetValue(source, out var bakeBlendShapeToggles))
+                {
                     if (bakeBlendShapeToggles.blendShapeFlags.Length != length)
                         bakeBlendShapeToggles.blendShapeFlags = new CombineBlendshapeFlags[length];
                     bakeBlendShapeToggles.blendShapeNames = skinnedMeshRenderer != null ? GetBlendshapeNamesArray(mesh) : new string[0];
-                } else {
+                }
+                else
+                {
                     bakeBlendShapeToggles = new BakeBlendShapeToggles(
                         new CombineBlendshapeFlags[length],
                         CombineMeshFlags.CreateBoneForNonSkinnedMesh |
@@ -301,9 +347,11 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner {
             foreach (var source in oldSources) bakeBlendShapeMap.Remove(source);
         }
 
-        void TryMarkUnusedBlendshapes(bool isDeselect = false) {
+        void TryMarkUnusedBlendshapes(bool isDeselect = false)
+        {
             var unusedBlendshapes = new HashSet<string>();
-            foreach (var renderer in sources) {
+            foreach (var renderer in sources)
+            {
                 if (!(renderer is SkinnedMeshRenderer smr)) continue;
                 if (!bakeBlendShapeMap.TryGetValue(renderer, out var bakeBlendShapeToggles)) continue;
                 var mesh = smr.sharedMesh;
@@ -311,12 +359,15 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner {
                 unusedBlendshapes.Clear();
                 unusedBlendshapes.UnionWith(EnumerateBlendshapeNames(mesh));
                 unusedBlendshapes.ExceptWith(ReportUsedBlendshapes(smr, mesh));
-                if (isDeselect) {
+                if (isDeselect)
+                {
                     for (int i = 0, count = mesh.blendShapeCount; i < count; i++)
                         if (!unusedBlendshapes.Contains(mesh.GetBlendShapeName(i)))
                             bakeBlendShapeToggles.blendShapeFlags[i] = CombineBlendshapeFlags.None;
-                } else
-                    foreach (var key in unusedBlendshapes) {
+                }
+                else
+                    foreach (var key in unusedBlendshapes)
+                    {
                         int index = mesh.GetBlendShapeIndex(key);
                         if (index >= 0 && bakeBlendShapeToggles.blendShapeFlags[index] == CombineBlendshapeFlags.None)
                             bakeBlendShapeToggles.blendShapeFlags[index] = CombineBlendshapeFlags.CombineBlendShape;
@@ -324,16 +375,20 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner {
             }
         }
 
-        static IEnumerable<string> ReportUsedBlendshapes(Renderer renderer, Mesh mesh) {
+        static IEnumerable<string> ReportUsedBlendshapes(Renderer renderer, Mesh mesh)
+        {
             const string PREFIX = "blendShape.";
             var animClips = new HashSet<(Transform, AnimationClip)>();
-            foreach (var (component, controller) in GetAnimationSources(renderer)) {
+            foreach (var (component, controller) in GetAnimationSources(renderer))
+            {
                 if (controller == null) continue;
                 foreach (var clip in controller.animationClips)
                     animClips.Add((component, clip));
             }
-            foreach (var (transform, clip) in animClips) {
-                foreach (var binding in AnimationUtility.GetCurveBindings(clip)) {
+            foreach (var (transform, clip) in animClips)
+            {
+                foreach (var binding in AnimationUtility.GetCurveBindings(clip))
+                {
                     if (binding.type != typeof(SkinnedMeshRenderer) ||
                         binding.path != GetTransformPath(renderer.transform, transform) ||
                         binding.propertyName != PREFIX && !binding.propertyName.StartsWith(PREFIX)) continue;
@@ -342,17 +397,21 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner {
             }
             // VRChat Avatars (SDK3)
             var type = Type.GetType("VRC.SDK3.Avatars.Components.VRCAvatarDescriptor, VRCSDK3A", false);
-            if (type != null) {
+            if (type != null)
+            {
                 dynamic avatarDescriptor = renderer.GetComponentInParent(type);
-                if (avatarDescriptor != null) {
-                    if (avatarDescriptor.VisemeSkinnedMesh == renderer) {
+                if (avatarDescriptor != null)
+                {
+                    if (avatarDescriptor.VisemeSkinnedMesh == renderer)
+                    {
                         var visemeBlendShapes = avatarDescriptor.VisemeBlendShapes;
                         if (visemeBlendShapes is string[] visemeBlendShapesArray)
                             foreach (var name in visemeBlendShapesArray)
                                 yield return name;
                     }
                     var customEyeLookSettings = avatarDescriptor.customEyeLookSettings;
-                    if (customEyeLookSettings.eyelidsSkinnedMesh == renderer) {
+                    if (customEyeLookSettings.eyelidsSkinnedMesh == renderer)
+                    {
                         var eyelidsBlendshapes = customEyeLookSettings.eyelidsBlendshapes;
                         if (eyelidsBlendshapes is int[] eyelidsBlendshapesArray)
                             foreach (var index in eyelidsBlendshapesArray)
@@ -363,21 +422,26 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner {
             // TODO: Add more animation sources from other SDKs
         }
 
-        static IEnumerable<(Transform, RuntimeAnimatorController)> GetAnimationSources(Renderer renderer) {
+        static IEnumerable<(Transform, RuntimeAnimatorController)> GetAnimationSources(Renderer renderer)
+        {
             var animator = renderer.GetComponentInParent<Animator>();
-            if (animator != null) {
+            if (animator != null)
+            {
                 var controller = animator.runtimeAnimatorController;
-                if (controller != null) {
+                if (controller != null)
+                {
                     yield return (animator.transform, controller);
                 }
             }
             var gathered = new HashSet<(Transform, RuntimeAnimatorController)>();
             // VRChat Avatars (Universal SDK Versions)
             var type = Type.GetType("VRC.SDKBase.VRC_AvatarDescriptor, VRCSDKBase", false);
-            if (type != null) {
+            if (type != null)
+            {
                 var avatarDescriptor = renderer.GetComponentInParent(type);
                 if (avatarDescriptor != null)
-                    using (var so = new SerializedObject(avatarDescriptor)) {
+                    using (var so = new SerializedObject(avatarDescriptor))
+                    {
                         var prop = so.GetIterator();
                         while (prop.Next(true))
                             if (prop.propertyType == SerializedPropertyType.ObjectReference &&

--- a/Editor/MeshCombinerWindow.CombineMeshes.cs
+++ b/Editor/MeshCombinerWindow.CombineMeshes.cs
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * The MIT License (MIT)
  *
  * Copyright (c) 2023 Jeremy Lam aka. Vistanz
@@ -27,29 +27,25 @@ using UnityEditor;
 using UnityEditorInternal;
 using JLChnToZ.CommonUtils;
 
-namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner
-{
+namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner {
     using static Utils;
-    public partial class MeshCombinerWindow : EditorWindow
-    {
+    public partial class MeshCombinerWindow : EditorWindow {
         const string COMBINE_MESH_INFO = "Select (skinned) mesh renderer(s) and/or its parent, and click \"+\" button to add to the combine list.\n" +
             "Even it is not necessary in many cases, you may drag to change the processing order.\n" +
             "You can expand the options such as baking blendshapes by clicking on the arrow on the left.\n" +
             "You can use the checkbox on the right to toggle all options within the renderer while expanded the view.\n" +
             "It is recommend to bake the blendshapes that unlikely to be changed after build for better performance and smaller file size.\n" +
             "If the blendshape is a \"anti-penetration\" key for hiding skins under clothes, you can use the dropdown to select remove blendshape vertex to reduce triangles and vertices.";
-
+            
 
         [Serializable]
-        struct BakeBlendShapeToggles
-        {
+        struct BakeBlendShapeToggles {
             public CombineBlendshapeFlags[] blendShapeFlags;
             public CombineMeshFlags combineMeshFlags;
             public bool toggleState;
             public string[] blendShapeNames;
 
-            public BakeBlendShapeToggles(CombineBlendshapeFlags[] blendShapeFlags, CombineMeshFlags combineMeshFlags, bool toggleState, string[] blendShapeNames)
-            {
+            public BakeBlendShapeToggles(CombineBlendshapeFlags[] blendShapeFlags, CombineMeshFlags combineMeshFlags, bool toggleState, string[] blendShapeNames) {
                 this.blendShapeFlags = blendShapeFlags;
                 this.combineMeshFlags = combineMeshFlags;
                 this.toggleState = toggleState;
@@ -57,7 +53,7 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner
             }
         }
 
-        [Serializable] class BakeBlendShapeMap : SerializableDictionary<Renderer, BakeBlendShapeToggles> { }
+        [Serializable] class BakeBlendShapeMap : SerializableDictionary<Renderer, BakeBlendShapeToggles> {}
 
         Vector2 sourceListScrollPos;
         List<Renderer> sources = new List<Renderer>();
@@ -66,34 +62,28 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner
         BlendShapeCopyMode blendShapeCopyMode = BlendShapeCopyMode.Vertices;
         ReorderableList sourceList;
 
-        static CombineMeshFlags DrawFlag(CombineMeshFlags mergeFlags, string label, CombineMeshFlags flag)
-        {
+        static CombineMeshFlags DrawFlag(CombineMeshFlags mergeFlags, string label, CombineMeshFlags flag) {
             EditorGUI.BeginChangeCheck();
             var state = EditorGUILayout.ToggleLeft(label, mergeFlags.HasFlag(flag));
-            if (EditorGUI.EndChangeCheck())
-            {
+            if (EditorGUI.EndChangeCheck()) {
                 if (state) mergeFlags |= flag;
                 else mergeFlags &= ~flag;
             }
             return mergeFlags;
         }
 
-        static CombineMeshFlags DrawFlag(CombineMeshFlags mergeFlags, Rect position, string label, CombineMeshFlags flag)
-        {
+        static CombineMeshFlags DrawFlag(CombineMeshFlags mergeFlags, Rect position, string label, CombineMeshFlags flag) {
             EditorGUI.BeginChangeCheck();
             var state = EditorGUI.ToggleLeft(position, label, mergeFlags.HasFlag(flag));
-            if (EditorGUI.EndChangeCheck())
-            {
+            if (EditorGUI.EndChangeCheck()) {
                 if (state) mergeFlags |= flag;
                 else mergeFlags &= ~flag;
             }
             return mergeFlags;
         }
 
-        void InitCombineMeshTab()
-        {
-            sourceList = new ReorderableList(sources, typeof(Renderer), true, false, true, true)
-            {
+        void InitCombineMeshTab() {
+            sourceList = new ReorderableList(sources, typeof(Renderer), true, false, true, true) {
                 drawElementCallback = OnListDrawElement,
                 elementHeightCallback = OnListGetElementHeight,
                 onAddCallback = OnListAdd,
@@ -103,8 +93,7 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner
             };
         }
 
-        void DrawCombineMeshTab()
-        {
+        void DrawCombineMeshTab() {
             EditorGUILayout.HelpBox(COMBINE_MESH_INFO, MessageType.Info);
             sourceListScrollPos = EditorGUILayout.BeginScrollView(sourceListScrollPos);
             sourceList.DoLayoutList();
@@ -116,9 +105,8 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner
             if (GUILayout.Button("Sort by Mesh Sorting Order Descending ↓", EditorStyles.miniButton, GUILayout.ExpandWidth(false))) AutoOrderRenderer();
             EditorGUILayout.EndHorizontal();
             #endregion
-
+            
             EditorGUILayout.BeginHorizontal();
-
             EditorGUI.BeginChangeCheck();
             var newDestination = EditorGUILayout.ObjectField("Destination", destination, typeof(Renderer), true) as Renderer;
             if (EditorGUI.EndChangeCheck() && (
@@ -126,26 +114,21 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner
                 newDestination is SkinnedMeshRenderer ||
                 (newDestination is MeshRenderer && newDestination.TryGetComponent(out MeshFilter _))))
                 destination = newDestination;
-            if (destination == null)
-            {
-                if (GUILayout.Button("Auto Create", EditorStyles.miniButtonLeft, GUILayout.ExpandWidth(false)))
-                {
+            if (destination == null) {
+                if (GUILayout.Button("Auto Create", EditorStyles.miniButtonLeft, GUILayout.ExpandWidth(false))) {
                     destination = AutoCreateRenderer<SkinnedMeshRenderer>();
                     EditorGUIUtility.PingObject(destination);
                 }
                 if (dropdownIcon == null) dropdownIcon = EditorGUIUtility.IconContent("d_icon dropdown");
                 var dropdownButtonSize = EditorStyles.miniButtonRight.CalcSize(dropdownIcon);
                 var dropdownButtonRect = GUILayoutUtility.GetRect(dropdownButtonSize.x, dropdownButtonSize.y, EditorStyles.miniButtonRight, GUILayout.ExpandWidth(false));
-                if (GUI.Button(dropdownButtonRect, dropdownIcon, EditorStyles.miniButtonRight))
-                {
+                if (GUI.Button(dropdownButtonRect, dropdownIcon, EditorStyles.miniButtonRight)) {
                     var menu = new GenericMenu();
-                    menu.AddItem(new GUIContent("Skinned Mesh Renderer"), false, () =>
-                    {
+                    menu.AddItem(new GUIContent("Skinned Mesh Renderer"), false, () => {
                         destination = AutoCreateRenderer<SkinnedMeshRenderer>();
                         EditorGUIUtility.PingObject(destination);
                     });
-                    menu.AddItem(new GUIContent("Mesh Renderer"), false, () =>
-                    {
+                    menu.AddItem(new GUIContent("Mesh Renderer"), false, () => {
                         destination = AutoCreateRenderer<MeshRenderer>();
                         EditorGUIUtility.PingObject(destination);
                     });
@@ -163,17 +146,15 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner
             EditorGUILayout.EndHorizontal();
         }
 
-
-        void OnListDrawElement(Rect rect, int index, bool isActive, bool isFocused)
-        {
+        
+        void OnListDrawElement(Rect rect, int index, bool isActive, bool isFocused) {
             bool isMeshRenderer = destination is MeshRenderer;
             var renderer = sources[index];
             rect.height = EditorGUIUtility.singleLineHeight;
             var rect2 = rect;
             rect2.xMin += 12;
             rect2.xMax -= 150;
-            if (GUI.Button(rect2, renderer == null ? new GUIContent("(Missing)") : EditorGUIUtility.ObjectContent(renderer, renderer.GetType()), EditorStyles.label))
-            {
+            if (GUI.Button(rect2, renderer == null ? new GUIContent("(Missing)") : EditorGUIUtility.ObjectContent(renderer, renderer.GetType()), EditorStyles.label)) {
                 EditorGUIUtility.PingObject(renderer);
                 if (!isFocused) sourceList.index = index;
             }
@@ -187,8 +168,7 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner
             if (!bakeBlendShapeToggles.toggleState) return;
             rect2.width = rect.width;
             rect2.y += EditorGUIUtility.singleLineHeight;
-            if (renderer is SkinnedMeshRenderer)
-            {
+            if (renderer is SkinnedMeshRenderer) {
                 var newFlags = bakeBlendShapeToggles.combineMeshFlags;
                 newFlags = DrawFlag(newFlags, rect2, "Remove sub meshes without materials", CombineMeshFlags.RemoveSubMeshWithoutMaterials);
                 rect2.y += EditorGUIUtility.singleLineHeight;
@@ -196,16 +176,14 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner
                 rect2.y += EditorGUIUtility.singleLineHeight;
                 newFlags = DrawFlag(newFlags, rect2, "Remove mesh portions with 0-scale bones", CombineMeshFlags.RemoveMeshPortionsWithZeroScaleBones);
                 rect2.y += EditorGUIUtility.singleLineHeight;
-                if (newFlags != bakeBlendShapeToggles.combineMeshFlags)
-                {
+                if (newFlags != bakeBlendShapeToggles.combineMeshFlags) {
                     bakeBlendShapeToggles.combineMeshFlags = newFlags;
                     bakeBlendShapeMap[renderer] = bakeBlendShapeToggles;
                 }
                 if (bakeBlendShapeToggles.blendShapeFlags.Length <= 0) return;
                 bool state = false, isMixed = false, isMixed2 = false;
                 var states2 = CombineBlendshapeFlags.None;
-                for (var i = 0; i < bakeBlendShapeToggles.blendShapeFlags.Length; i++)
-                {
+                for (var i = 0; i < bakeBlendShapeToggles.blendShapeFlags.Length; i++) {
                     bool currentState = isMeshRenderer || bakeBlendShapeToggles.blendShapeFlags[i] != CombineBlendshapeFlags.None;
                     rect2.width = rect.width - 128 - rect2.x;
                     EditorGUI.BeginChangeCheck();
@@ -224,13 +202,10 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner
                     if (EditorGUI.EndChangeCheck()) bakeBlendShapeToggles.blendShapeFlags[i] = flag;
                     rect2.y += EditorGUIUtility.singleLineHeight;
                     rect2.x = rect.x;
-                    if (i == 0)
-                    {
+                    if (i == 0) {
                         state = currentState;
                         states2 = flag;
-                    }
-                    else
-                    {
+                    } else {
                         if (currentState != state)
                             isMixed = true;
                         if (flag != states2)
@@ -258,28 +233,23 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner
                 if (EditorGUI.EndChangeCheck())
                     for (var i = 0; i < bakeBlendShapeToggles.blendShapeFlags.Length; i++)
                         bakeBlendShapeToggles.blendShapeFlags[i] = state ? CombineBlendshapeFlags.CombineBlendShape : CombineBlendshapeFlags.None;
-            }
-            else if (renderer is MeshRenderer)
-            {
+            } else if (renderer is MeshRenderer) {
                 var newFlags = bakeBlendShapeToggles.combineMeshFlags;
                 EditorGUI.BeginChangeCheck();
                 EditorGUI.BeginDisabledGroup(isMeshRenderer);
                 if (isMeshRenderer) newFlags &= ~CombineMeshFlags.CreateBoneForNonSkinnedMesh;
                 newFlags = DrawFlag(newFlags, rect2, "Create bone for this mesh renderer", CombineMeshFlags.CreateBoneForNonSkinnedMesh);
                 EditorGUI.EndDisabledGroup();
-                if (EditorGUI.EndChangeCheck())
-                {
+                if (EditorGUI.EndChangeCheck()) {
                     bakeBlendShapeToggles.combineMeshFlags = newFlags;
                     bakeBlendShapeMap[renderer] = bakeBlendShapeToggles;
                 }
             }
         }
 
-        float OnListGetElementHeight(int index)
-        {
+        float OnListGetElementHeight(int index) {
             var source = sources[index];
-            if (bakeBlendShapeMap.TryGetValue(source, out var bakeBlendShapeToggles))
-            {
+            if (bakeBlendShapeMap.TryGetValue(source, out var bakeBlendShapeToggles)) {
                 if (bakeBlendShapeToggles.toggleState)
                     return EditorGUIUtility.singleLineHeight * (
                         source is SkinnedMeshRenderer ?
@@ -289,8 +259,7 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner
             return EditorGUIUtility.singleLineHeight;
         }
 
-        void OnListAdd(ReorderableList list)
-        {
+        void OnListAdd(ReorderableList list) {
             var count = sources.Count;
             sources.AddRange(Selection.GetFiltered<Renderer>(SelectionMode.Deep).Where(IsAcceptableObject));
             if (count == sources.Count) return;
@@ -298,8 +267,7 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner
             RefreshCombineMeshOptions();
         }
 
-        void OnListRemove(ReorderableList list)
-        {
+        void OnListRemove(ReorderableList list) {
             sources.RemoveAt(list.index);
             RefreshCombineMeshOptions();
         }
@@ -307,31 +275,25 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner
         private void OnListDrawNoneElement(Rect rect) =>
             EditorGUI.LabelField(rect, "Click \"+\" button to add selected (skinned) mesh renderer to combine.");
 
-        void RefreshCombineMeshOptions()
-        {
+        void RefreshCombineMeshOptions() {
             var oldSources = new HashSet<Renderer>(bakeBlendShapeMap.Keys);
-            foreach (var source in sources)
-            {
+            foreach (var source in sources) {
                 Mesh mesh = null;
                 var skinnedMeshRenderer = source as SkinnedMeshRenderer;
                 if (skinnedMeshRenderer != null)
                     mesh = skinnedMeshRenderer.sharedMesh;
-                else
-                {
+                else {
                     var meshRenderer = source as MeshRenderer;
                     if (meshRenderer != null && source.TryGetComponent(out MeshFilter meshFilter))
                         mesh = meshFilter.sharedMesh;
                 }
                 if (mesh == null) continue;
                 int length = skinnedMeshRenderer != null ? mesh.blendShapeCount : 0;
-                if (bakeBlendShapeMap.TryGetValue(source, out var bakeBlendShapeToggles))
-                {
+                if (bakeBlendShapeMap.TryGetValue(source, out var bakeBlendShapeToggles)) {
                     if (bakeBlendShapeToggles.blendShapeFlags.Length != length)
                         bakeBlendShapeToggles.blendShapeFlags = new CombineBlendshapeFlags[length];
                     bakeBlendShapeToggles.blendShapeNames = skinnedMeshRenderer != null ? GetBlendshapeNamesArray(mesh) : new string[0];
-                }
-                else
-                {
+                } else {
                     bakeBlendShapeToggles = new BakeBlendShapeToggles(
                         new CombineBlendshapeFlags[length],
                         CombineMeshFlags.CreateBoneForNonSkinnedMesh |
@@ -347,11 +309,9 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner
             foreach (var source in oldSources) bakeBlendShapeMap.Remove(source);
         }
 
-        void TryMarkUnusedBlendshapes(bool isDeselect = false)
-        {
+        void TryMarkUnusedBlendshapes(bool isDeselect = false) {
             var unusedBlendshapes = new HashSet<string>();
-            foreach (var renderer in sources)
-            {
+            foreach (var renderer in sources) {
                 if (!(renderer is SkinnedMeshRenderer smr)) continue;
                 if (!bakeBlendShapeMap.TryGetValue(renderer, out var bakeBlendShapeToggles)) continue;
                 var mesh = smr.sharedMesh;
@@ -359,15 +319,12 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner
                 unusedBlendshapes.Clear();
                 unusedBlendshapes.UnionWith(EnumerateBlendshapeNames(mesh));
                 unusedBlendshapes.ExceptWith(ReportUsedBlendshapes(smr, mesh));
-                if (isDeselect)
-                {
+                if (isDeselect) {
                     for (int i = 0, count = mesh.blendShapeCount; i < count; i++)
                         if (!unusedBlendshapes.Contains(mesh.GetBlendShapeName(i)))
                             bakeBlendShapeToggles.blendShapeFlags[i] = CombineBlendshapeFlags.None;
-                }
-                else
-                    foreach (var key in unusedBlendshapes)
-                    {
+                } else
+                    foreach (var key in unusedBlendshapes) {
                         int index = mesh.GetBlendShapeIndex(key);
                         if (index >= 0 && bakeBlendShapeToggles.blendShapeFlags[index] == CombineBlendshapeFlags.None)
                             bakeBlendShapeToggles.blendShapeFlags[index] = CombineBlendshapeFlags.CombineBlendShape;
@@ -375,20 +332,16 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner
             }
         }
 
-        static IEnumerable<string> ReportUsedBlendshapes(Renderer renderer, Mesh mesh)
-        {
+        static IEnumerable<string> ReportUsedBlendshapes(Renderer renderer, Mesh mesh) {
             const string PREFIX = "blendShape.";
             var animClips = new HashSet<(Transform, AnimationClip)>();
-            foreach (var (component, controller) in GetAnimationSources(renderer))
-            {
+            foreach (var (component, controller) in GetAnimationSources(renderer)) {
                 if (controller == null) continue;
                 foreach (var clip in controller.animationClips)
                     animClips.Add((component, clip));
             }
-            foreach (var (transform, clip) in animClips)
-            {
-                foreach (var binding in AnimationUtility.GetCurveBindings(clip))
-                {
+            foreach (var (transform, clip) in animClips) {
+                foreach (var binding in AnimationUtility.GetCurveBindings(clip)) {
                     if (binding.type != typeof(SkinnedMeshRenderer) ||
                         binding.path != GetTransformPath(renderer.transform, transform) ||
                         binding.propertyName != PREFIX && !binding.propertyName.StartsWith(PREFIX)) continue;
@@ -397,21 +350,17 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner
             }
             // VRChat Avatars (SDK3)
             var type = Type.GetType("VRC.SDK3.Avatars.Components.VRCAvatarDescriptor, VRCSDK3A", false);
-            if (type != null)
-            {
+            if (type != null) {
                 dynamic avatarDescriptor = renderer.GetComponentInParent(type);
-                if (avatarDescriptor != null)
-                {
-                    if (avatarDescriptor.VisemeSkinnedMesh == renderer)
-                    {
+                if (avatarDescriptor != null) {
+                    if (avatarDescriptor.VisemeSkinnedMesh == renderer) {
                         var visemeBlendShapes = avatarDescriptor.VisemeBlendShapes;
                         if (visemeBlendShapes is string[] visemeBlendShapesArray)
                             foreach (var name in visemeBlendShapesArray)
                                 yield return name;
                     }
                     var customEyeLookSettings = avatarDescriptor.customEyeLookSettings;
-                    if (customEyeLookSettings.eyelidsSkinnedMesh == renderer)
-                    {
+                    if (customEyeLookSettings.eyelidsSkinnedMesh == renderer) {
                         var eyelidsBlendshapes = customEyeLookSettings.eyelidsBlendshapes;
                         if (eyelidsBlendshapes is int[] eyelidsBlendshapesArray)
                             foreach (var index in eyelidsBlendshapesArray)
@@ -422,26 +371,21 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner
             // TODO: Add more animation sources from other SDKs
         }
 
-        static IEnumerable<(Transform, RuntimeAnimatorController)> GetAnimationSources(Renderer renderer)
-        {
+        static IEnumerable<(Transform, RuntimeAnimatorController)> GetAnimationSources(Renderer renderer) {
             var animator = renderer.GetComponentInParent<Animator>();
-            if (animator != null)
-            {
+            if (animator != null) {
                 var controller = animator.runtimeAnimatorController;
-                if (controller != null)
-                {
+                if (controller != null) {
                     yield return (animator.transform, controller);
                 }
             }
             var gathered = new HashSet<(Transform, RuntimeAnimatorController)>();
             // VRChat Avatars (Universal SDK Versions)
             var type = Type.GetType("VRC.SDKBase.VRC_AvatarDescriptor, VRCSDKBase", false);
-            if (type != null)
-            {
+            if (type != null) {
                 var avatarDescriptor = renderer.GetComponentInParent(type);
                 if (avatarDescriptor != null)
-                    using (var so = new SerializedObject(avatarDescriptor))
-                    {
+                    using (var so = new SerializedObject(avatarDescriptor)) {
                         var prop = so.GetIterator();
                         while (prop.Next(true))
                             if (prop.propertyType == SerializedPropertyType.ObjectReference &&

--- a/Editor/MeshCombinerWindow.cs
+++ b/Editor/MeshCombinerWindow.cs
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * The MIT License (MIT)
  *
  * Copyright (c) 2023 Jeremy Lam aka. Vistanz
@@ -26,11 +26,13 @@ using UnityEngine;
 using UnityEditor;
 using UnityObject = UnityEngine.Object;
 
-namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner {
+namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner
+{
     using JLChnToZ.CommonUtils;
     using static Utils;
-    
-    public partial class MeshCombinerWindow : EditorWindow {
+
+    public partial class MeshCombinerWindow : EditorWindow
+    {
         const string COMBINE_INFO = "Click combine to...\n" +
             "- Combine meshes while retains blendshapes and bones\n" +
             "- Merge sub meshes with same material into one\n" +
@@ -41,14 +43,15 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner {
             "- Deactivates combined mesh renderer sources";
         const string MESH_RENDERER_INFO = "The destination is an ordinary mesh renderer, all blend shapes and bones will enforced to combined and dereferenced.";
 
-        public enum Tabs : byte {
+        public enum Tabs : byte
+        {
             CombineMeshes,
             CombineBones,
             BlendshapesRename,
             Cleanup,
         }
 
-        [Serializable] class TransformSet : SerializableSet<Transform> {}
+        [Serializable] class TransformSet : SerializableSet<Transform> { }
 
         static string[] tabNames;
         static GUIContent dropdownIcon;
@@ -59,10 +62,12 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner {
         [MenuItem("JLChnToZ/Tools/Skinned Mesh Combiner")]
         public static void ShowWindow() => GetWindow<MeshCombinerWindow>("Skinned Mesh Combiner").Show(true);
 
-        protected virtual void OnEnable() {
+        protected virtual void OnEnable()
+        {
             if (tabNames == null) tabNames = Array.ConvertAll(Enum.GetNames(typeof(Tabs)), ObjectNames.NicifyVariableName);
             InitCombineMeshTab();
-            switch (currentTab) {
+            switch (currentTab)
+            {
                 case Tabs.CombineMeshes: RefreshCombineMeshOptions(); break;
                 case Tabs.CombineBones: RefreshBones(); break;
                 case Tabs.BlendshapesRename: RefreshBlendshapes(); break;
@@ -71,14 +76,16 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner {
             OnListAdd(sourceList);
         }
 
-        protected virtual void OnGUI() {
+        protected virtual void OnGUI()
+        {
             EditorGUILayout.BeginHorizontal();
             EditorGUI.BeginChangeCheck();
             currentTab = (Tabs)GUILayout.Toolbar((int)currentTab, tabNames, GUILayout.ExpandWidth(true));
             bool tabChanged = EditorGUI.EndChangeCheck();
             EditorGUILayout.EndHorizontal();
-            switch (currentTab) {
-                case Tabs.CombineMeshes: 
+            switch (currentTab)
+            {
+                case Tabs.CombineMeshes:
                     if (tabChanged) RefreshCombineMeshOptions();
                     DrawCombineMeshTab();
                     break;
@@ -100,7 +107,8 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner {
             EditorGUI.BeginDisabledGroup(sources.Count == 0);
             if (GUILayout.Button("Combine")) Combine();
             EditorGUI.EndDisabledGroup();
-            if (GUILayout.Button("Clear")) {
+            if (GUILayout.Button("Clear"))
+            {
                 sources.Clear();
                 bakeBlendShapeMap.Clear();
                 boneReamp.Clear();
@@ -119,18 +127,22 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner {
             HandleDrop();
         }
 
-        void HandleDrop() {
+        void HandleDrop()
+        {
             var ev = Event.current;
-            switch (ev.type) {
+            switch (ev.type)
+            {
                 case EventType.DragUpdated:
-                    if (DragAndDrop.objectReferences.SelectMany(GetRenderers).Any(IsAcceptableObject)) {
+                    if (DragAndDrop.objectReferences.SelectMany(GetRenderers).Any(IsAcceptableObject))
+                    {
                         DragAndDrop.visualMode = DragAndDropVisualMode.Copy;
                         ev.Use();
                     }
                     break;
                 case EventType.DragPerform:
                     var objectRefs = DragAndDrop.objectReferences.SelectMany(GetRenderers).ToArray();
-                    if (objectRefs.Any(IsAcceptableObject)) {
+                    if (objectRefs.Any(IsAcceptableObject))
+                    {
                         DragAndDrop.visualMode = DragAndDropVisualMode.Copy;
                         DragAndDrop.AcceptDrag();
                         sources.AddRange(objectRefs.Where(IsAcceptableObject));
@@ -142,7 +154,8 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner {
             }
         }
 
-        static IEnumerable<Renderer> GetRenderers(UnityObject obj) {
+        static IEnumerable<Renderer> GetRenderers(UnityObject obj)
+        {
             if (obj is GameObject go)
                 return go.GetComponentsInChildren<Renderer>(true);
             else if (obj is Renderer r)
@@ -159,7 +172,8 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner {
 
         bool IsAcceptableObject(MeshRenderer mr) => mr != null && mr.TryGetComponent(out MeshFilter mf) && mf.sharedMesh != null && !sources.Contains(mr);
 
-        T AutoCreateRenderer<T>() where T : Renderer {
+        T AutoCreateRenderer<T>() where T : Renderer
+        {
             var commonParent = FindCommonParent(sources.Select(x => x.transform));
             var type = typeof(T);
             var newChild = type.Name == "MeshRenderer" ?
@@ -171,29 +185,64 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner {
             return newChild.GetComponent<T>();
         }
 
-        void Combine() {
+        /// <summary>
+        /// Auto Order Renderer
+        /// </summary>
+        /// <param name="order">Default Descending</param>
+        void AutoOrderRenderer(bool descending = true)
+        {
+            // Convert sourceList to List<Renderer> for sorting
+            List<Renderer> renderers = new List<Renderer>();
+            foreach (var item in sourceList.list)
+            {
+                renderers.Add(item as Renderer);
+            }
+            if (descending)
+            {
+                // Ascending
+                renderers.Sort((a, b) => b.sortingOrder.CompareTo(a.sortingOrder));
+            }
+            else
+            {
+                // Descending
+                renderers.Sort((a, b) => a.sortingOrder.CompareTo(b.sortingOrder));
+            }
+            sourceList.list.Clear();
+            foreach (var item in renderers)
+            {
+                sourceList.list.Add(item);
+            }
+        }
+
+        void Combine()
+        {
             RefreshCombineMeshOptions();
             boneReamp.Clear();
-            foreach (var bone in bonesToMergeUpwards) {
+            foreach (var bone in bonesToMergeUpwards)
+            {
                 var targetBone = bone;
-                while (targetBone != null && bonesToMergeUpwards.Contains(targetBone)) {
+                while (targetBone != null && bonesToMergeUpwards.Contains(targetBone))
+                {
                     targetBone = targetBone.parent;
                     boneReamp[bone] = targetBone;
                 }
             }
             unusedTransforms.Clear();
             safeDeleteTransforms.Clear();
-            foreach (var source in sources) {
+            foreach (var source in sources)
+            {
                 unusedTransforms.Add(source.transform);
                 if (source is SkinnedMeshRenderer skinnedMeshRenderer)
                     unusedTransforms.UnionWith(skinnedMeshRenderer.bones.Where(b => b != null));
             }
             bool shouldPingDestination = false;
-            if (destination == null) {
+            if (destination == null)
+            {
                 destination = AutoCreateRenderer<SkinnedMeshRenderer>();
                 shouldPingDestination = true;
             }
-            var saveAssetDefaultPath = sources.Select(source => {
+            var saveAssetDefaultPath = sources.Select(source =>
+            {
                 var skinnedMeshRenderer = source as SkinnedMeshRenderer;
                 if (skinnedMeshRenderer != null) return skinnedMeshRenderer.sharedMesh;
                 var meshRenderer = source as MeshRenderer;
@@ -205,12 +254,14 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner {
             .Where(p => !string.IsNullOrEmpty(p) && p.StartsWith("Assets/"))
             .Select(System.IO.Path.GetDirectoryName)
             .FirstOrDefault() ?? string.Empty;
-            var mesh = SkinnedMeshCombinerCore.Combine(sources.Select(source => {
+            var mesh = SkinnedMeshCombinerCore.Combine(sources.Select(source =>
+            {
                 if (bakeBlendShapeMap.TryGetValue(source, out var bakeBlendShapeToggles))
                     return (source, bakeBlendShapeToggles.blendShapeFlags, bakeBlendShapeToggles.combineMeshFlags);
                 return (source, null, CombineMeshFlags.None);
             }).ToArray(), destination, mergeFlags, blendShapeCopyMode, boneReamp, blendshapeNameMap);
-            if (mesh != null) {
+            if (mesh != null)
+            {
                 mesh.Optimize();
                 if (destination is SkinnedMeshRenderer skinnedMeshRenderer)
                     unusedTransforms.ExceptWith(skinnedMeshRenderer.bones);
@@ -220,7 +271,8 @@ namespace JLChnToZ.EditorExtensions.SkinnedMeshCombiner {
                 if (autoCleanup) SafeDeleteAllObjects();
                 if (shouldPingDestination) EditorGUIUtility.PingObject(destination);
                 currentTab = Tabs.Cleanup;
-            } else
+            }
+            else
                 Debug.LogError("Failed to combine meshes.");
         }
     }


### PR DESCRIPTION
When merging Spine baked bones, it is necessary to correctly sort the Mesh, otherwise the rendering order will be disordered.